### PR TITLE
fix chef dependencies to be ruby 1.8 compatible

### DIFF
--- a/templates/SLES-11-SP4-DVD-x86_64-GM/postinstall.sh
+++ b/templates/SLES-11-SP4-DVD-x86_64-GM/postinstall.sh
@@ -27,6 +27,8 @@ echo -e "UseDNS no\n" >> /etc/ssh/sshd_config
 
 # install chef
 echo -e "\ninstall chef ..."
+gem install mixlib-shellout -v 1.4.0 --no-ri --no-rdoc
+gem install highline -v 1.6.21 --no-ri --no-rdoc
 gem install chef -v 11.18.12 --no-ri --no-rdoc
 
 # install puppet


### PR DESCRIPTION
this should be the last part in the stack to get fixed :boom: 